### PR TITLE
Tireons bugfix - crashing when launching pod with cargo in Space Exploration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.5.2
+Date: 2022-10-23
+Bugfixes:
+    - Fixed crash when launching pod with cargo in Space Exploration mod
+    https://mods.factorio.com/mod/attach-notes/discussion/62c12765caa02a955856391a
+---------------------------------------------------------------------------------------------------
 Version: 0.5.1
 Date: 2021-04-26
   Changes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "attach-notes",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "factorio_version": "1.1",
   "title": "Attach Notes",
   "author": "321freddy",

--- a/scripts/entity-notes/controller.lua
+++ b/scripts/entity-notes/controller.lua
@@ -173,7 +173,11 @@ function this.on_entity_destroyed(event)
 	for index,cache in pairs(global.cache) do
 		if not util.isValid(game.players[index]) then
 			global.cache[index] = nil
-		elseif cache.openedEntityGui and cache.openedEntityGui.unit_number == unitNumber then
+		elseif cache.openedEntityGui
+		-- Tireons bugfix 0.5.2
+		and cache.openedEntityGui.valid
+		-- bugfix end
+		and cache.openedEntityGui.unit_number == unitNumber then
 			this.destroyGUI(game.players[index], cache)
 		end
 	end


### PR DESCRIPTION
Did it myself... Not yet tested at all above that launch now did not crash the game.

Obviously probem was in timing of sequence when pod gets destroyed in one surface and created (probably with different ID) in another, while event got the ID of the destroyed one.

Fix is quite simple, so I do not expect massive troubles, however some testing would be fine (I am playing Factorio actively, so will see myself too).